### PR TITLE
img tag has 'empty' content model as per html5 spec

### DIFF
--- a/Haste/Perch.hs
+++ b/Haste/Perch.hs
@@ -112,7 +112,8 @@ canvas cont = nelem "canvas" `child` cont
 
 center cont= nelem "center" `child` cont
 
-img cont = nelem "img" `child` cont
+img :: Perch
+img = nelem "img"
 
 li cont= nelem "li" `child` cont
 


### PR DESCRIPTION
As per the HTML4 spec (http://www.w3.org/TR/html401/struct/objects.html#h-13.2) and HTML5 spec (http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element), the IMG tag will never have children. 

This patch disallows creation of IMG-tags with child elements.
