### PR TITLE
adding HTML5 elements, from Text.Blaze.Html5

### DIFF
--- a/Haste/Perch.hs
+++ b/Haste/Perch.hs
@@ -85,38 +85,131 @@ addEvent be event action= Perch $ \e -> do
         setAttr e' atr "true"
         return e'
 
+-- Leaf DOM nodes
+--
+area = nelem "area"
+base = nelem "base"
+br = nelem "br"
+col = nelem "col"
+embed = nelem "embed"
+hr = nelem "hr"
+img = nelem "img"
+input = nelem "input"
+keygen = nelem "keygen"
+link = nelem "link"
+menuitem = nelem "menuitem"
+meta = nelem "meta"
+param = nelem "param"
+source = nelem "source"
+track = nelem "track"
+wbr = nelem "wbr"
 
-br= nelem "br"
+-- Parent DOM nodes
+--
+a cont = nelem  "a" `child` cont
+abbr cont = nelem  "abbr" `child` cont
+address cont = nelem  "address" `child` cont
+article cont = nelem  "article" `child` cont
+aside cont = nelem  "aside" `child` cont
+audio cont = nelem  "audio" `child` cont
+b cont = nelem  "b" `child` cont
+bdo cont = nelem  "bdo" `child` cont
+blockquote cont = nelem  "blockquote" `child` cont
+body cont = nelem  "body" `child` cont
+button cont = nelem  "button" `child` cont
+canvas cont = nelem  "canvas" `child` cont
+caption cont = nelem  "caption" `child` cont
+cite cont = nelem  "cite" `child` cont
+code cont = nelem  "code" `child` cont
+colgroup cont = nelem  "colgroup" `child` cont
+command cont = nelem  "command" `child` cont
+datalist cont = nelem  "datalist" `child` cont
+dd cont = nelem  "dd" `child` cont
+del cont = nelem  "del" `child` cont
+details cont = nelem  "details" `child` cont
+dfn cont = nelem  "dfn" `child` cont
+div cont = nelem  "div" `child` cont
+dl cont = nelem  "dl" `child` cont
+dt cont = nelem  "dt" `child` cont
+em cont = nelem  "em" `child` cont
+fieldset cont = nelem  "fieldset" `child` cont
+figcaption cont = nelem  "figcaption" `child` cont
+figure cont = nelem  "figure" `child` cont
+footer cont = nelem  "footer" `child` cont
+form cont = nelem  "form" `child` cont
+h1 cont = nelem  "h1" `child` cont
+h2 cont = nelem  "h2" `child` cont
+h3 cont = nelem  "h3" `child` cont
+h4 cont = nelem  "h4" `child` cont
+h5 cont = nelem  "h5" `child` cont
+h6 cont = nelem  "h6" `child` cont
+head cont = nelem  "head" `child` cont
+header cont = nelem  "header" `child` cont
+hgroup cont = nelem  "hgroup" `child` cont
+html cont = nelem  "html" `child` cont
+i cont = nelem  "i" `child` cont
+iframe cont = nelem  "iframe" `child` cont
+ins cont = nelem  "ins" `child` cont
+kbd cont = nelem  "kbd" `child` cont
+label cont = nelem  "label" `child` cont
+legend cont = nelem  "legend" `child` cont
+li cont = nelem  "li" `child` cont
+map cont = nelem  "map" `child` cont
+mark cont = nelem  "mark" `child` cont
+menu cont = nelem  "menu" `child` cont
+meter cont = nelem  "meter" `child` cont
+nav cont = nelem  "nav" `child` cont
+noscript cont = nelem  "noscript" `child` cont
+object cont = nelem  "object" `child` cont
+ol cont = nelem  "ol" `child` cont
+optgroup cont = nelem  "optgroup" `child` cont
+option cont = nelem  "option" `child` cont
+output cont = nelem  "output" `child` cont
+p cont = nelem  "p" `child` cont
+pre cont = nelem  "pre" `child` cont
+progress cont = nelem  "progress" `child` cont
+q cont = nelem  "q" `child` cont
+rp cont = nelem  "rp" `child` cont
+rt cont = nelem  "rt" `child` cont
+ruby cont = nelem  "ruby" `child` cont
+samp cont = nelem  "samp" `child` cont
+script cont = nelem  "script" `child` cont
+section cont = nelem  "section" `child` cont
+select cont = nelem  "select" `child` cont
+small cont = nelem  "small" `child` cont
+span cont = nelem  "span" `child` cont
+strong cont = nelem  "strong" `child` cont
+{-style cont = nelem  "style" `child` cont-}
+sub cont = nelem  "sub" `child` cont
+summary cont = nelem  "summary" `child` cont
+sup cont = nelem  "sup" `child` cont
+table cont = nelem  "table" `child` cont
+tbody cont = nelem  "tbody" `child` cont
+td cont = nelem  "td" `child` cont
+textarea cont = nelem  "textarea" `child` cont
+tfoot cont = nelem  "tfoot" `child` cont
+th cont = nelem  "th" `child` cont
+thead cont = nelem  "thead" `child` cont
+time cont = nelem  "time" `child` cont
+title cont = nelem  "title" `child` cont
+tr cont = nelem  "tr" `child` cont
+ul cont = nelem  "ul" `child` cont
+var cont = nelem  "var" `child` cont
+video cont = nelem  "video" `child` cont
 
 ctag tag cont= nelem tag `child` cont
 
-div cont=  nelem "div" `child`  cont
+-- HTML4 support
+center cont= nelem "center" `child` cont
 
-p cont = nelem "p" `child` cont
+noHtml= mempty :: Perch
 
-b cont = nelem "b" `child` cont
-
-a cont = nelem "a" `child` cont
-
-h1 cont= nelem "h1" `child` cont
-
+-- Attributes
 (!) pe atrib = \e ->  pe e `attr` atrib
 
 atr n v= (n,v)
 
 style= atr "style"
-
-noHtml= mempty :: Perch
-
-canvas cont = nelem "canvas" `child` cont
-
-center cont= nelem "center" `child` cont
-
-img cont = nelem "img" `child` cont
-
-li cont= nelem "li" `child` cont
-
-ul cont= nelem "ul" `child` cont
 
 id = atr "id"
 
@@ -127,11 +220,3 @@ height= atr "height"
 href= atr "href"
 
 src= atr "src"
-
-table rows= nelem "table" `child` rows
-
-tr rows= nelem "tr" `child` rows
-
-td e= nelem "td" `child` e
-
-


### PR DESCRIPTION
Grabbed list of HTML5 elements from Text.Blaze.Html5 (https://github.com/jaspervdj/blaze-html/blob/master/src/Util/GenerateHtmlCombinators.hs). This should probably be generated (like Blaze) in the future - but this will at least get folks up-and-running!

Note that there is a valid STYLE tag in HTML4 and HTML5 - yet the top-level "style" function is used for attribute-setting.
