### PR TITLE
Fixed typo on elem id reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import Prelude hiding (div)
 
 main :: IO ()
 main = do
-  withElem "root" $ build $ do
+  withElem "idelem" $ build $ do
     div $ do
       addEvent this Click $ \_ -> alert "hello, world!"
       div $ do


### PR DESCRIPTION
There was a typo in my last commit.